### PR TITLE
bug: auctions timestamps

### DIFF
--- a/apps/valence-app/src/app/auctions/components/LiveAuctionsTable.tsx
+++ b/apps/valence-app/src/app/auctions/components/LiveAuctionsTable.tsx
@@ -113,15 +113,19 @@ export function LiveAuctionsTable({
   });
 
   const { startTime, endTime } = useMemo(() => {
+    const mostRecentBlock = auctionsData.auctions?.sort((a, b) => {
+      // descending order
+      return b.auction.start_block - a.auction.start_block;
+    });
     return {
       startTime: getBlockDate({
         estimatedBlockTime: chainConfig.estBlockTime,
-        blockNumber: auctionsData.auctions[0]?.auction.start_block,
+        blockNumber: mostRecentBlock[0]?.auction.start_block,
         currentBlockNumber: auctionsData?.currentBlock,
       }),
       endTime: getBlockDate({
         estimatedBlockTime: chainConfig.estBlockTime,
-        blockNumber: auctionsData.auctions[0]?.auction.end_block,
+        blockNumber: mostRecentBlock[0]?.auction.end_block,
         currentBlockNumber: auctionsData?.currentBlock,
       }),
     };
@@ -220,6 +224,7 @@ export function LiveAuctionsTable({
   const now = new Date();
   const [localStartDate, setLocalStartDate] = useState<Date>(now);
   const [localEndDate, setLocalEndDate] = useState<Date>(now);
+
   useEffect(() => {
     // ensures time is local time and and server time
     setLocalStartDate(new Date(startTime));

--- a/apps/valence-app/src/const/config/chain.ts
+++ b/apps/valence-app/src/const/config/chain.ts
@@ -90,7 +90,7 @@ const SupportedChainConfig: Record<SupportedChainId, SupportedChainConfig> = {
     },
     celatoneUrl: "https://neutron.celat.one/neutron-1",
     mintscanUrl: "https://www.mintscan.io/neutron",
-    estBlockTime: 2.42,
+    estBlockTime: 3.16,
   },
   "pion-1": {
     chain: NEUTRON_TESTNET_CHAIN,

--- a/apps/valence-app/src/utils/block-time.ts
+++ b/apps/valence-app/src/utils/block-time.ts
@@ -1,4 +1,5 @@
 import { UTCDate } from "@date-fns/utc";
+import { subSeconds } from "date-fns";
 
 export function getBlockDate({
   estimatedBlockTime,
@@ -11,6 +12,6 @@ export function getBlockDate({
 }) {
   const blockDifference = currentBlockNumber - blockNumber;
   const secondsDifference = blockDifference * estimatedBlockTime;
-  const date = new UTCDate(UTCDate.now() - secondsDifference * 1000);
-  return date;
+  const nowDate = new UTCDate(UTCDate.now());
+  return subSeconds(nowDate, secondsDifference);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced auction timing calculations to use the most recent auction data
	- Updated block time estimation for the Neutron chain
	- Refined block date calculation method

- **Configuration Updates**
	- Adjusted estimated block time for "neutron-1" chain from 2.42 to 3.16 seconds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->